### PR TITLE
Silence loading of preprocessors

### DIFF
--- a/org-pandoc-import.el
+++ b/org-pandoc-import.el
@@ -108,7 +108,7 @@ RECOGNISED-EXTENSIONS defaults to '(\"NAME\"), and PANDOC-TYPE to \"NAME\"."
                               (expand-file-name (concat s-name ".el") org-pandoc-import-preprocessor-folder))
                              (preprocerror-func (intern (format "org-pandoc-import-%s-preprocessor" s-name))))
                          (when (file-exists-p preprocessor-file)
-                           (load-file preprocessor-file)
+                           (load preprocessor-file nil t)
                            (fboundp preprocerror-func)
                            preprocerror-func)))
          (common-args (list pandoc-type 'in-file format-extensions format-args format-filters


### PR DESCRIPTION
I try to keep my Emacs config quiet while loading. This should do the same thing, but won't print a message for each processor loading.