### PR TITLE
Fix byte-compile warnings

### DIFF
--- a/org-pandoc-import.el
+++ b/org-pandoc-import.el
@@ -38,6 +38,8 @@
 
 ;;; Code:
 
+(require 'subr-x)
+
 (defgroup org-pandoc-import nil
   "Provides methods to convert other markup files to Org."
   :tag "Org Pandoc Import"


### PR DESCRIPTION
```
In org-pandoc-import-as-org:
org-pandoc-import.el:301:4:Warning: ‘(backend
    (org-pandoc-import-find-associated-backend (or in-file
    (buffer-file-name))))’ is a malformed function
org-pandoc-import.el:303:75:Warning: reference to free variable ‘backend’

In org-pandoc-import-to-org:
org-pandoc-import.el:316:4:Warning: ‘(backend
    (org-pandoc-import-find-associated-backend (or in-file
    (buffer-file-name))))’ is a malformed function
org-pandoc-import.el:318:75:Warning: reference to free variable ‘backend’

In end of data:
org-pandoc-import.el:352:1:Warning: the function ‘if-let’ is not known to be
    defined.
```